### PR TITLE
Enable coconut to fetch information from different enviroments

### DIFF
--- a/lib/coconut/fetch_service.rb
+++ b/lib/coconut/fetch_service.rb
@@ -39,6 +39,10 @@ module Coconut
       config.server['customers'][customer]['address']
     end
 
+    def environment
+      config.server['customers'][customer]['environment'] || 'integration'
+    end
+
     def server_file(file)
       "#{customers_path}/#{file}.#{customer}"
     end
@@ -61,7 +65,7 @@ module Coconut
     end
 
     def read_yml(path)
-      YAML.load_file(path)['integration']
+      YAML.load_file(path)[environment]
     end
   end
 end


### PR DESCRIPTION
Enable Coconut to fetch information from different environments:

On the coconut.yml, on the server/customer section, you can add the attribute environment, to fetch config files from servers that aren't using integration. By default, the customers will fetch the integration configuration.

``` yml
server:
  ssh_user: user_name
  shared_folder: folder_path
  customers:
    $costumer:
      address: ip_address
      enviroment: enviroment
```
