### PR TITLE
Add required dependencies to the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in coconut.gemspec
 gemspec
-
-gem 'thor'
-gem 'awesome_print'

--- a/coconut.gemspec
+++ b/coconut.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["coconut"]
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "awesome_print", "~> 1.8"
+  spec.add_development_dependency "rake", "~> 10"
 end

--- a/lib/coconut/config_folder.rb
+++ b/lib/coconut/config_folder.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Coconut
 
   class ConfigFolder


### PR DESCRIPTION
 Loosen bundler and rake dependencies because I didn't see any direct requirement in the code for a particular version.

The production/cli code directly references `awesome_print` and `thor` so they should be specified as dependencies of the gemspec, instead of the Gemfile.

EDIT:
Also added a missing `require 'file_utils'` to fix #9 